### PR TITLE
Parametrised export options and general improvements

### DIFF
--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -4,88 +4,296 @@ import time
 import csv
 import re
 
+class Arguments():
+	""" argparse wrapper, to reduce code verbosity """
+	__parser = None
+	__args = None
 
-database_location = "C:\\ProgramData\\GOG.com\\Galaxy\\storage\\galaxy-2.0.db"
-platforms = {"3do": "3DO Interactive Multiplayer", "3ds": "Nintendo 3DS", "aion": "Aion", "aionl": "Aion: Legions of War", "amazon": "Amazon", "amiga": "Amiga", "arc": "ARC", "atari": "Atari 2600", "battlenet": "Battle.net", "bb": "BestBuy", "beamdog": "Beamdog", "bethesda": "Bethesda.net", "blade": "Blade & Soul", "c64": "Commodore 64", "d2d": "Direct2Drive", "dc": "Dreamcast", "discord": "Discord", "dotemu": "DotEmu", "egg": "Newegg", "elites": "Elite Dangerous", "epic": "Epic Games Store", "eso": "The Elder Scrolls Online", "fanatical": "Fanatical", "ffxi": "Final Fantasy XI", "ffxiv": "Final Fantasy XIV", "fxstore": "Placeholder", "gamehouse": "GameHouse", "gamesessions": "GameSessions", "gameuk": "GAME UK", "generic": "Other", "gg": "GamersGate", "glyph": "Trion World", "gmg": "Green Man Gaming", "gog": "GOG", "gw": "Guild Wars", "gw2": "Guild Wars 2", "humble": "Humble Bundle", "indiegala": "IndieGala", "itch": "Itch.io", "jaguar": "Atari Jaguar", "kartridge": "Kartridge", "lin2": "Lineage 2", "minecraft": "Minecraft", "n64": "Nintendo 64", "ncube": "Nintendo GameCube", "nds": "Nintendo DS", "neo": "NeoGeo", "nes": "Nintendo Entertainment System", "ngameboy": "Game Boy", "nswitch": "Nintendo Switch", "nuuvem": "Nuuvem", "nwii": "Wii", "nwiiu": "Wii U", "oculus": "Oculus", "origin": "Origin", "paradox": "Paradox Plaza", "pathofexile": "Path of Exile", "pce": "PC Engine", "playasia": "Play-Asia", "playfire": "Playfire", "ps2": "PlayStation 2", "psn": "PlayStation Network", "psp": "PlayStation Portable", "psvita": "PlayStation Vita", "psx": "PlayStation", "riot": "Riot", "rockstar": "Rockstar Games Launcher", "saturn": "Sega Saturn", "sega32": "32X", "segacd": "Sega CD", "segag": "Sega Genesis", "sms": "Sega Master System", "snes": "Super Nintendo Entertainment System", "stadia": "Google Stadia", "star": "Star Citizen", "steam": "Steam", "test": "Test", "totalwar": "Total War", "twitch": "Twitch", "unknown": "Unknown", "uplay": "Uplay", "vision": "ColecoVision", "wargaming": "Wargaming", "weplay": "WePlay", "winstore": "Windows Store", "xboxog": "Xbox", "xboxone": "Xbox Live", "zx": "ZX Spectrum PC"}
+	def __init__(self, args, **kwargs):
+		import argparse
+		self.__parser = argparse.ArgumentParser(**kwargs)
+		for arg in args:
+			self.__parser.add_argument(*arg[0], **arg[1])
+		self.__args = self.__parser.parse_args()
 
-conn = sqlite3.connect(database_location)
-cursor = conn.cursor()
+	def help(self):
+		self.__parser.print_help()
 
-# gamePieceTypeId is stored in GamePieceTypes
-cursor.execute("""SELECT id FROM GamePieceTypes WHERE type='originalMeta'""")
-originalMetaID = cursor.fetchone()[0]
-cursor.execute("""SELECT id FROM GamePieceTypes WHERE type='meta'""")
-metaID = cursor.fetchone()[0]
-cursor.execute("""SELECT id FROM GamePieceTypes WHERE type='originalTitle'""")
-originalTitleID = cursor.fetchone()[0]
-cursor.execute("""SELECT id FROM GamePieceTypes WHERE type='title'""")
-titleID = cursor.fetchone()[0]
-cursor.execute("""SELECT id FROM GamePieceTypes WHERE type='originalImages'""")
-imagesID = cursor.fetchone()[0]
-cursor.execute("""SELECT id FROM GamePieceTypes WHERE type='allGameReleases'""")
-releasesList = cursor.fetchone()[0]
-# Create a view of GameLinks joined on GamePieces for a full owned game data DB
-owned_game_database = """CREATE TEMP VIEW MasterList AS
+	def anyOption(self, exceptions):
+		for k,v in self.__args.__dict__.items():
+			if (k not in exceptions) and v:
+				return True
+		return False
+
+	def __getattr__(self, name):
+		return getattr(self.__args, name)
+
+def extractData(args):
+	database_location = "C:\\ProgramData\\GOG.com\\Galaxy\\storage\\galaxy-2.0.db"
+	platforms = {"3do": "3DO Interactive Multiplayer", "3ds": "Nintendo 3DS", "aion": "Aion", "aionl": "Aion: Legions of War", "amazon": "Amazon", "amiga": "Amiga", "arc": "ARC", "atari": "Atari 2600", "battlenet": "Battle.net", "bb": "BestBuy", "beamdog": "Beamdog", "bethesda": "Bethesda.net", "blade": "Blade & Soul", "c64": "Commodore 64", "d2d": "Direct2Drive", "dc": "Dreamcast", "discord": "Discord", "dotemu": "DotEmu", "egg": "Newegg", "elites": "Elite Dangerous", "epic": "Epic Games Store", "eso": "The Elder Scrolls Online", "fanatical": "Fanatical", "ffxi": "Final Fantasy XI", "ffxiv": "Final Fantasy XIV", "fxstore": "Placeholder", "gamehouse": "GameHouse", "gamesessions": "GameSessions", "gameuk": "GAME UK", "generic": "Other", "gg": "GamersGate", "glyph": "Trion World", "gmg": "Green Man Gaming", "gog": "GOG", "gw": "Guild Wars", "gw2": "Guild Wars 2", "humble": "Humble Bundle", "indiegala": "IndieGala", "itch": "Itch.io", "jaguar": "Atari Jaguar", "kartridge": "Kartridge", "lin2": "Lineage 2", "minecraft": "Minecraft", "n64": "Nintendo 64", "ncube": "Nintendo GameCube", "nds": "Nintendo DS", "neo": "NeoGeo", "nes": "Nintendo Entertainment System", "ngameboy": "Game Boy", "nswitch": "Nintendo Switch", "nuuvem": "Nuuvem", "nwii": "Wii", "nwiiu": "Wii U", "oculus": "Oculus", "origin": "Origin", "paradox": "Paradox Plaza", "pathofexile": "Path of Exile", "pce": "PC Engine", "playasia": "Play-Asia", "playfire": "Playfire", "ps2": "PlayStation 2", "psn": "PlayStation Network", "psp": "PlayStation Portable", "psvita": "PlayStation Vita", "psx": "PlayStation", "riot": "Riot", "rockstar": "Rockstar Games Launcher", "saturn": "Sega Saturn", "sega32": "32X", "segacd": "Sega CD", "segag": "Sega Genesis", "sms": "Sega Master System", "snes": "Super Nintendo Entertainment System", "stadia": "Google Stadia", "star": "Star Citizen", "steam": "Steam", "test": "Test", "totalwar": "Total War", "twitch": "Twitch", "unknown": "Unknown", "uplay": "Uplay", "vision": "ColecoVision", "wargaming": "Wargaming", "weplay": "WePlay", "winstore": "Windows Store", "xboxog": "Xbox", "xboxone": "Xbox Live", "zx": "ZX Spectrum PC"}
+
+	def id(name):
+		""" Returns the numeric ID for the specified type """
+		return cursor.execute('SELECT id FROM GamePieceTypes WHERE type="{}"'.format(name)).fetchone()[0]
+
+	def jls(name, bReturnCleanedString=False):
+		""" json.loads(`name`), optionally returning the purified sub-object of the same name,
+		    for cases such as {`name`: {`name`: "string"}}
+		"""
+		v = json.loads(result[positions[name]])
+		return re.sub(r'<br\s*/?>', '\\\\n', v[name].replace('\n', '\\n')) if bReturnCleanedString else v
+
+
+	def prepare(resultName, fields, dbField=None, dbRef=None, dbCondition=None, dbResultField=None, dbGroupBy=None):
+		""" Wrapper around the statement preparation and result parsing\n
+			`resultName` cli argument variable name\n
+			`fields` {`title` to be inserted in the CSV: `boolean condition`, …}\n
+			SELECT `dbField` FROM `dbRef` WHERE `dbCondition`\n
+			SELECT `dbResultField` FROM MasterDB GROUP BY `dbGroupBy`
+		"""
+		# CSV field names
+		for name,condition in fields.items():
+			if condition:
+				fieldnames.append(name)
+
+		if dbField:
+			og_fields.append(', {}'.format(dbField))
+			# Position of the results
+			positions[resultName] = prepare.nextPos
+			prepare.nextPos += 1
+		if dbRef:
+			og_references.append(', {}'.format(dbRef))
+		if dbCondition:
+			og_conditions.append(' AND ({})'.format(dbCondition))
+		if dbResultField:
+			og_resultFields.append(dbResultField)
+		if dbGroupBy:
+			og_resultGroupBy.append(dbGroupBy)
+
+	from contextlib import contextmanager
+	@contextmanager
+	def OpenDB():
+		# Prepare the DB connection
+		_connection = sqlite3.connect(database_location)
+		_cursor = _connection.cursor()
+
+		_exception = None
+		try:
+			yield _cursor
+		except Exception as e:
+			_exception = e
+
+		# Close the DB connection
+		_cursor.close()
+		_connection.close()
+
+		# Re-raise the unhandled exception if needed
+		if _exception:
+			raise _exception
+
+	with OpenDB() as cursor:
+		# Create a view of GameLinks joined on GamePieces for a full owned game data DB
+		owned_game_database = """CREATE TEMP VIEW MasterList AS
 				SELECT GamePieces.releaseKey, GamePieces.gamePieceTypeId, GamePieces.value FROM GameLinks
 				JOIN GamePieces ON GameLinks.releaseKey = GamePieces.releaseKey;"""
-# Create filtered view of owned games with game times using multiple joins
-owned_game_filtered_data = """CREATE TEMP VIEW MasterDB AS SELECT DISTINCT(MasterList.releaseKey) AS releaseKey,
-				MasterList.value AS title, MC1.value AS metadata, MC2.value AS platformList, MC3.value as images,
-				GameTimes.minutesInGame AS time from MasterList, MasterList AS MC1, MasterList AS MC2,
-				MasterList AS MC3, GameTimes WHERE ((MasterList.gamePieceTypeId={0}) OR (MasterList.gamePieceTypeId={1}))
-				AND ((MC1.gamePieceTypeId={2}) OR (MC1.gamePieceTypeId={3})) AND MC2.gamePieceTypeId={4}
-				AND MC3.gamePieceTypeId={5} AND MC1.releaseKey=MasterList.releaseKey AND MC2.releaseKey=MasterList.releaseKey AND
-				MC3.releaseKey=MasterList.releaseKey AND GameTimes.releaseKey=MasterList.releaseKey ORDER BY title;""".format(
-					originalTitleID,
-					titleID,
-					originalMetaID,
-					metaID,
-					releasesList,
-					imagesID
-				)
-# Display each game and its details along with corresponding release key grouped by releasesList
-unique_game_data = """SELECT GROUP_CONCAT(DISTINCT MasterDB.releaseKey), MasterDB.title, MasterDB.metadata, sum(MasterDB.time), MasterDB.images
-				FROM MasterDB GROUP BY MasterDB.platformList ORDER BY MasterDB.title;"""
-cursor.execute(owned_game_database)
-cursor.execute(owned_game_filtered_data)
-cursor.execute(unique_game_data)
-title_regex = re.compile(r"""(?<=\{"title":").*(?="})""")
-with open("gameDB.csv", "w", encoding='utf-8', newline='') as csvfile:
-	fieldnames = ['title', 'platformList', 'developers', 'publishers', 'releaseDate', 'genres', 'themes', 'criticsScore', 'gameMins', 'backgroundImage', 'squareIcon', 'verticalCover']
-	writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-	writer.writeheader()
-	while True:
-		result = cursor.fetchone()
-		if result:
-			# JSON string needs to be converted to dict
-			# For json.load() to work correctly, all double quotes must be correctly escaped
-			metadata = json.loads(result[2].replace('"','\"'))
-			row = metadata
-			row['title'] = result[1].replace("\\","")
-			row['title'] = title_regex.findall(row["title"])[0]
-			row['platformList'] = []
-			if any(platform in releaseKey for platform in platforms for releaseKey in result[0].split(",")):
-				row['platformList'] = set(platforms[platform] for releaseKey in result[0].split(",") for platform in platforms if releaseKey.startswith(platform))
-			else:
-				row['platformList'].append("Placeholder")
-			if metadata['releaseDate']:
-				row['releaseDate'] = time.strftime("%Y-%m-%d", time.localtime(metadata['releaseDate']))
-			else:
-				row['releaseDate'] = metadata['releaseDate']
-			if metadata['criticsScore']:
-				row['criticsScore'] = round(metadata['criticsScore'])
-			else:
-				row['criticsScore'] = metadata['criticsScore']
-			images = json.loads(result[4])
-			row['backgroundImage'] = images['background'] or ''
-			row['squareIcon'] = images['squareIcon'] or ''
-			row['verticalCover'] = images['verticalCover'] or ''
-			for key, value in row.items():
-				if type(value) == list or type(value) == set:
-					row[key] = ",".join(value)
-			row['gameMins'] = result[3]
-			writer.writerow(row)
-		else:
-			break
-cursor.close()
-conn.close()
+
+		# Set up default queries and processing metadata, and always extract the game title along with any parameters
+		prepare.nextPos = 2
+		positions = {'releaseKey': 0, 'title': 1}
+		fieldnames = ['title']
+		og_fields = ["""CREATE TEMP VIEW MasterDB AS SELECT DISTINCT(MasterList.releaseKey) AS releaseKey, MasterList.value AS title"""]
+		og_references = [""" FROM MasterList"""]
+		og_conditions = [""" WHERE ((MasterList.gamePieceTypeId={}) OR (MasterList.gamePieceTypeId={}))""".format(id('originalTitle'), id('title'))]
+		og_order = """ ORDER BY title;"""
+		og_resultFields = ['GROUP_CONCAT(DISTINCT MasterDB.releaseKey)', 'MasterDB.title']
+		og_resultGroupBy = ['MasterDB.title']
+
+		# Create parameterised filtered view of owned games using multiple joins
+		if args.all or args.summary:
+			prepare(
+				'summary',
+				{'summary': True},
+				'SUMMARY.value AS summary',
+				'MasterList AS SUMMARY',
+				'(SUMMARY.releaseKey=MasterList.releaseKey) AND (SUMMARY.gamePieceTypeId={})'.format(id('summary')),
+				'MasterDB.summary'
+			)
+
+		if args.all or args.platforms:
+			prepare(
+				'platforms',
+				{'platformList': True},
+			)
+
+		if args.all or args.criticsScore or args.developers or args.genres or args.publishers or args.releaseDate or args.themes:
+			prepare(
+				'metadata',
+				{
+					'criticsScore': args.all or args.criticsScore,
+					'developers': args.all or args.developers,
+					'genres': args.all or args.genres,
+					'publishers': args.all or args.publishers,
+					'releaseDate': args.all or args.releaseDate,
+					'themes': args.all or args.themes,
+				},
+				'METADATA.value AS metadata',
+				'MasterList AS METADATA',
+				'(METADATA.releaseKey=MasterList.releaseKey) AND ((METADATA.gamePieceTypeId={}) OR (METADATA.gamePieceTypeId={}))'.format(id('originalMeta'), id('meta')),
+				'MasterDB.metadata'
+			)
+
+		if args.all or args.playtime:
+			prepare(
+				'playtime',
+				{'gameMins': True},
+				'GAMETIMES.minutesInGame AS time',
+				'GAMETIMES',
+				'GAMETIMES.releaseKey=MasterList.releaseKey',
+				'sum(MasterDB.time)'
+			)
+
+		if args.all or args.imageBackground or args.imageSquare or args.imageVertical:
+			prepare(
+				'images',
+				{
+					'backgroundImage': args.all or args.imageBackground,
+					'squareIcon': args.all or args.imageSquare,
+					'verticalCover': args.all or args.imageVertical
+				},
+				'IMAGES.value AS images',
+				'MasterList AS IMAGES',
+				'(IMAGES.releaseKey=MasterList.releaseKey) AND (IMAGES.gamePieceTypeId={})'.format(id('originalImages')),
+				'MasterDB.images'
+			)
+
+		# Display each game and its details along with corresponding release key grouped by releasesList
+		unique_game_data = """SELECT {} FROM MasterDB GROUP BY {} ORDER BY MasterDB.title;""".format(
+			', '.join(og_resultFields),
+			', '.join(og_resultGroupBy)
+		)
+
+		# Perform the queries
+		cursor.execute(owned_game_database)
+		cursor.execute(''.join(og_fields + og_references + og_conditions) + og_order)
+		cursor.execute(unique_game_data)
+
+		#title_regex = re.compile(r"""(?<=\{"title":").*(?="})""")
+		with open("gameDB.csv", "w", encoding='utf-8', newline='') as csvfile:
+			writer = csv.DictWriter(csvfile, fieldnames=fieldnames, delimiter=args.delimiter)
+			writer.writeheader()
+			while True:
+				result = cursor.fetchone()
+				if not result:
+					break
+
+				# JSON string needs to be converted to dict
+				# For json.load() to work correctly, all double quotes must be correctly escaped
+				row = {'title': jls('title', True)}
+
+				# Playtime
+				if args.all or args.playtime:
+					row['gameMins'] = result[positions['playtime']]
+
+				# Summaries
+				if args.all or args.summary:
+					row['summary'] = jls('summary', True)
+
+				# Platforms
+				if args.all or args.platforms:
+					rkeys = result[positions['releaseKey']].split(',')
+					if any(platform in releaseKey for platform in platforms for releaseKey in rkeys):
+						row['platformList'] = set(platforms[platform] for releaseKey in rkeys for platform in platforms if releaseKey.startswith(platform))
+					else:
+						row['platformList'] = ["Placeholder"]
+
+				# Various metadata
+				if args.all or args.criticsScore or args.developers or args.genres or args.publishers or args.releaseDate or args.themes:
+					metadata = jls('metadata')
+
+					if args.all or args.criticsScore:
+						try:
+							row['criticsScore'] = round(metadata['criticsScore'])
+						except:
+							row['criticsScore'] = metadata['criticsScore']
+
+					if args.all or args.developers:
+						row['developers'] = metadata['developers']
+
+					if args.all or args.genres:
+						row['genres'] = metadata['genres']
+
+					if args.all or args.publishers:
+						row['publishers'] = metadata['publishers']
+
+					if args.all or args.releaseDate:
+						try:
+							row['releaseDate'] = time.strftime("%Y-%m-%d", time.localtime(metadata['releaseDate']))
+						except:
+							row['releaseDate'] = metadata['releaseDate']
+
+					if args.all or args.themes:
+						row['themes'] = metadata['themes']
+
+				# Original images
+				if args.all or args.imageBackground or args.imageSquare or args.imageVertical:
+					images = jls('images')
+					if args.all or args.imageBackground:
+						row['backgroundImage'] = images['background'] or ''
+					if args.all or args.imageSquare:
+						row['squareIcon'] = images['squareIcon'] or ''
+					if args.all or args.imageVertical:
+						row['verticalCover'] = images['verticalCover'] or ''
+
+				# CSV listification
+				for key, value in row.items():
+					if type(value) == list or type(value) == set:
+						row[key] = ",".join(value)
+
+				writer.writerow(row)
+
+if __name__ == "__main__":
+	def ba(variableName, description, defaultValue=False):
+		""" Boolean argument: creates a default boolean argument with the name of the storage variable and
+			the description to be shown in the help screen
+		"""
+		return {
+			'action': 'store_true',
+			'required': defaultValue,
+			'help': description,
+			'dest': variableName,
+		}
+
+	args = Arguments(
+		[
+			[
+				['-d'],
+				{
+					'default': ',',
+					'type': str,
+					'required': False,
+					'metavar': 'CHARACTER',
+					'help': 'CSV field separator, defaults to comma',
+					'dest': 'delimiter',
+				}
+			],
+			[['-a', '--all'], ba('all', 'extracts all the fields')],
+			[['--critics-score'], ba('criticsScore', 'critics rating score')],
+			[['--developers'], ba('developers', 'list of developers')],
+			[['--genres'], ba('genres', 'game genres')],
+			[['--image-background'], ba('imageBackground', 'background image')],
+			[['--image-square'], ba('imageSquare', 'square icon')],
+			[['--image-vertical'], ba('imageVertical', 'vertical cover image')],
+			[['--platforms'], ba('platforms', 'list of platforms the game is available on')],
+			[['--publishers'], ba('publishers', 'list of publishers')],
+			[['--release-date'], ba('releaseDate', 'release date of the software')],
+			[['--summary'], ba('summary', 'game summary')],
+			[['--themes'], ba('themes', 'game themes')],
+			[['--playtime'], ba('playtime', 'time spent playing the game')],
+		],
+		description='GOG Galaxy 2 exporter: scans the local Galaxy 2 database to export a list of games and related information into a CSV'
+	)
+
+	if args.anyOption(['delimiter']):
+		extractData(args)
+	else:
+		args.help()

--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -314,7 +314,7 @@ def extractData(args):
 							includeField(metadata, 'developers')
 							includeField(metadata, 'genres')
 							includeField(metadata, 'publishers')
-							includeField(metadata, 'criticsScore', fieldType=Type.DATE)
+							includeField(metadata, 'releaseDate', fieldType=Type.DATE)
 							includeField(metadata, 'themes')
 
 						# Original images

--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -101,12 +101,16 @@ def extractData(args):
 		prepare.nextPos = 2
 		positions = {'releaseKey': 0, 'title': 1}
 		fieldnames = ['title']
-		og_fields = ["""CREATE TEMP VIEW MasterDB AS SELECT DISTINCT(MasterList.releaseKey) AS releaseKey, MasterList.value AS title"""]
-		og_references = [""" FROM MasterList"""]
-		og_conditions = [""" WHERE ((MasterList.gamePieceTypeId={}) OR (MasterList.gamePieceTypeId={}))""".format(id('originalTitle'), id('title'))]
+		og_fields = ["""CREATE TEMP VIEW MasterDB AS SELECT DISTINCT(MasterList.releaseKey) AS releaseKey, MasterList.value AS title, PLATFORMS.value AS platformList"""]
+		og_references = [""" FROM MasterList, MasterList AS PLATFORMS"""]
+		og_conditions = [""" WHERE ((MasterList.gamePieceTypeId={}) OR (MasterList.gamePieceTypeId={})) AND ((PLATFORMS.releaseKey=MasterList.releaseKey) AND (PLATFORMS.gamePieceTypeId={}))""".format(
+					id('originalTitle'),
+					id('title'),
+					id('allGameReleases')
+				)]
 		og_order = """ ORDER BY title;"""
 		og_resultFields = ['GROUP_CONCAT(DISTINCT MasterDB.releaseKey)', 'MasterDB.title']
-		og_resultGroupBy = ['MasterDB.title']
+		og_resultGroupBy = ['MasterDB.platformList']
 
 		# Create parameterised filtered view of owned games using multiple joins
 		if args.all or args.summary:

--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -8,6 +8,7 @@ class Arguments():
 	""" argparse wrapper, to reduce code verbosity """
 	__parser = None
 	__args = None
+	__bAll = False  # Extract all fields
 
 	def __init__(self, args, **kwargs):
 		import argparse
@@ -15,6 +16,7 @@ class Arguments():
 		for arg in args:
 			self.__parser.add_argument(*arg[0], **arg[1])
 		self.__args = self.__parser.parse_args()
+		self.__bAll = getattr(self.__args, 'all')
 
 	def help(self):
 		self.__parser.print_help()
@@ -26,7 +28,8 @@ class Arguments():
 		return False
 
 	def __getattr__(self, name):
-		return getattr(self.__args, name)
+		ret = getattr(self.__args, name)
+		return (self.__bAll or ret) if isinstance(ret, bool) else ret
 
 def extractData(args):
 	database_location = "C:\\ProgramData\\GOG.com\\Galaxy\\storage\\galaxy-2.0.db"
@@ -113,7 +116,7 @@ def extractData(args):
 		og_resultGroupBy = ['MasterDB.platformList']
 
 		# Create parameterised filtered view of owned games using multiple joins
-		if args.all or args.summary:
+		if args.summary:
 			prepare(
 				'summary',
 				{'summary': True},
@@ -123,22 +126,22 @@ def extractData(args):
 				'MasterDB.summary'
 			)
 
-		if args.all or args.platforms:
+		if args.platforms:
 			prepare(
 				'platforms',
 				{'platformList': True},
 			)
 
-		if args.all or args.criticsScore or args.developers or args.genres or args.publishers or args.releaseDate or args.themes:
+		if args.criticsScore or args.developers or args.genres or args.publishers or args.releaseDate or args.themes:
 			prepare(
 				'metadata',
 				{
-					'criticsScore': args.all or args.criticsScore,
-					'developers': args.all or args.developers,
-					'genres': args.all or args.genres,
-					'publishers': args.all or args.publishers,
-					'releaseDate': args.all or args.releaseDate,
-					'themes': args.all or args.themes,
+					'criticsScore': args.criticsScore,
+					'developers': args.developers,
+					'genres': args.genres,
+					'publishers': args.publishers,
+					'releaseDate': args.releaseDate,
+					'themes': args.themes,
 				},
 				'METADATA.value AS metadata',
 				'MasterList AS METADATA',
@@ -146,7 +149,7 @@ def extractData(args):
 				'MasterDB.metadata'
 			)
 
-		if args.all or args.playtime:
+		if args.playtime:
 			prepare(
 				'playtime',
 				{'gameMins': True},
@@ -156,13 +159,13 @@ def extractData(args):
 				'sum(MasterDB.time)'
 			)
 
-		if args.all or args.imageBackground or args.imageSquare or args.imageVertical:
+		if args.imageBackground or args.imageSquare or args.imageVertical:
 			prepare(
 				'images',
 				{
-					'backgroundImage': args.all or args.imageBackground,
-					'squareIcon': args.all or args.imageSquare,
-					'verticalCover': args.all or args.imageVertical
+					'backgroundImage': args.imageBackground,
+					'squareIcon': args.imageSquare,
+					'verticalCover': args.imageVertical
 				},
 				'IMAGES.value AS images',
 				'MasterList AS IMAGES',
@@ -187,73 +190,76 @@ def extractData(args):
 			writer.writeheader()
 			while True:
 				result = cursor.fetchone()
-				if not result:
-					break
+				if not result: break  # Break on end
+				if not result[positions['playtime']]: continue  # Skip unfinished imports
 
-				# JSON string needs to be converted to dict
-				# For json.load() to work correctly, all double quotes must be correctly escaped
-				row = {'title': jls('title', True)}
+				try:
+					# JSON string needs to be converted to dict
+					# For json.load() to work correctly, all double quotes must be correctly escaped
+					row = {'title': jls('title', True)}
 
-				# Playtime
-				if args.all or args.playtime:
-					row['gameMins'] = result[positions['playtime']]
+					# Playtime
+					if args.playtime:
+						row['gameMins'] = result[positions['playtime']]
 
-				# Summaries
-				if args.all or args.summary:
-					row['summary'] = jls('summary', True)
+					# Summaries
+					if args.summary:
+						row['summary'] = jls('summary', True)
 
-				# Platforms
-				if args.all or args.platforms:
-					rkeys = result[positions['releaseKey']].split(',')
-					if any(platform in releaseKey for platform in platforms for releaseKey in rkeys):
-						row['platformList'] = set(platforms[platform] for releaseKey in rkeys for platform in platforms if releaseKey.startswith(platform))
-					else:
-						row['platformList'] = ["Placeholder"]
+					# Platforms
+					if args.platforms:
+						rkeys = result[positions['releaseKey']].split(',')
+						if any(platform in releaseKey for platform in platforms for releaseKey in rkeys):
+							row['platformList'] = set(platforms[platform] for releaseKey in rkeys for platform in platforms if releaseKey.startswith(platform))
+						else:
+							row['platformList'] = ["Placeholder"]
 
-				# Various metadata
-				if args.all or args.criticsScore or args.developers or args.genres or args.publishers or args.releaseDate or args.themes:
-					metadata = jls('metadata')
+					# Various metadata
+					if args.criticsScore or args.developers or args.genres or args.publishers or args.releaseDate or args.themes:
+						metadata = jls('metadata')
 
-					if args.all or args.criticsScore:
-						try:
-							row['criticsScore'] = round(metadata['criticsScore'])
-						except:
-							row['criticsScore'] = metadata['criticsScore']
+						if args.criticsScore:
+							try:
+								row['criticsScore'] = round(metadata['criticsScore'])
+							except:
+								row['criticsScore'] = metadata['criticsScore']
 
-					if args.all or args.developers:
-						row['developers'] = metadata['developers']
+						if args.developers:
+							row['developers'] = metadata['developers']
 
-					if args.all or args.genres:
-						row['genres'] = metadata['genres']
+						if args.genres:
+							row['genres'] = metadata['genres']
 
-					if args.all or args.publishers:
-						row['publishers'] = metadata['publishers']
+						if args.publishers:
+							row['publishers'] = metadata['publishers']
 
-					if args.all or args.releaseDate:
-						try:
-							row['releaseDate'] = time.strftime("%Y-%m-%d", time.localtime(metadata['releaseDate']))
-						except:
-							row['releaseDate'] = metadata['releaseDate']
+						if args.releaseDate:
+							try:
+								row['releaseDate'] = time.strftime("%Y-%m-%d", time.localtime(metadata['releaseDate']))
+							except:
+								row['releaseDate'] = metadata['releaseDate']
 
-					if args.all or args.themes:
-						row['themes'] = metadata['themes']
+						if args.themes:
+							row['themes'] = metadata['themes']
 
-				# Original images
-				if args.all or args.imageBackground or args.imageSquare or args.imageVertical:
-					images = jls('images')
-					if args.all or args.imageBackground:
-						row['backgroundImage'] = images['background'] or ''
-					if args.all or args.imageSquare:
-						row['squareIcon'] = images['squareIcon'] or ''
-					if args.all or args.imageVertical:
-						row['verticalCover'] = images['verticalCover'] or ''
+					# Original images
+					if args.imageBackground or args.imageSquare or args.imageVertical:
+						images = jls('images')
+						if args.imageBackground:
+							row['backgroundImage'] = images['background'] or ''
+						if args.imageSquare:
+							row['squareIcon'] = images['squareIcon'] or ''
+						if args.imageVertical:
+							row['verticalCover'] = images['verticalCover'] or ''
 
-				# CSV listification
-				for key, value in row.items():
-					if type(value) == list or type(value) == set:
-						row[key] = ",".join(value)
+					# CSV listification
+					for key, value in row.items():
+						if type(value) == list or type(value) == set:
+							row[key] = ",".join(value)
 
-				writer.writerow(row)
+					writer.writerow(row)
+				except:
+					print('Parsing failed on: {}'.format(result))
 
 if __name__ == "__main__":
 	def ba(variableName, description, defaultValue=False):

--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -4,6 +4,7 @@
 import csv
 from enum import Enum
 import json
+from natsort import natsorted
 from os.path import exists
 import re
 import sqlite3
@@ -259,6 +260,7 @@ def extractData(args):
 			if d:
 				for dlc in d:
 					dlcs.add(dlc)
+		results = natsorted(results, key=lambda r: str.casefold(r[1][positions['title']]))
 
 		# There are spurious random dlcNUMBERa entries in the library, compile a RegEx to filter them out
 		titleExclusion = re.compile(r'dlc_?[0-9]+_?a')
@@ -331,7 +333,7 @@ def extractData(args):
 						for k,v in row.items():
 							if v:
 								if list == type(v) or set == type(v):
-									row[k] = sorted(list(row[k]))
+									row[k] = natsorted(list(row[k]), key=str.casefold)
 							else:
 								row[k] = ''
 

--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -250,7 +250,7 @@ def extractData(args):
 					if args.platforms:
 						rkeys = result[positions['releaseKey']].split(',')
 						if any(platform in releaseKey for platform in platforms for releaseKey in rkeys):
-							row['platformList'] = set(platforms[platform] for releaseKey in rkeys for platform in platforms if releaseKey.startswith(platform))
+							row['platformList'] = list(set(platforms[platform] for releaseKey in rkeys for platform in platforms if releaseKey.startswith(platform)))
 						else:
 							row['platformList'] = []
 
@@ -270,11 +270,6 @@ def extractData(args):
 						includeField(images, 'backgroundImage', 'background', paramName='imageBackground')
 						includeField(images, 'squareIcon', paramName='imageSquare')
 						includeField(images, 'verticalCover', paramName='imageVertical')
-
-					# CSV listification
-					for key, value in row.items():
-						if type(value) == list or type(value) == set:
-							row[key] = ",".join(value)
 
 					writer.writerow(row)
 				except Exception as e:

--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -262,8 +262,15 @@ def extractData(args):
 					dlcs.add(dlc)
 		results = natsorted(results, key=lambda r: str.casefold(r[1][positions['title']]))
 
-		# There are spurious random dlcNUMBERa entries in the library, compile a RegEx to filter them out
-		titleExclusion = re.compile(r'dlc_?[0-9]+_?a')
+		# There are spurious random dlcNUMBERa entries in the library, plus a few DLCs which appear
+		# multiple times in different ways and are not attached to a game
+		titleExclusion = re.compile(r'^(?:'
+				r'dlc_?[0-9]+_?a'
+				r'|alternative look for yennefer(?:\s+\[[a-z]+\])?'
+				r'|beard and hairstyle set for geralt(?:\s+\[[a-z]+\])?'
+				r'|new quest - contract: missing miners(?:\s+\[[a-z]+\])?'
+				r'|temerian armor set(?:\s+\[[a-z]+\])?'
+		r')$')
 
 		# Compile the CSV
 		try:
@@ -280,7 +287,7 @@ def extractData(args):
 						# For json.load() to work correctly, all double quotes must be correctly escaped
 						try:
 							row = {'title': jld('title', True)}
-							if (not row['title']) or (titleExclusion.match(row['title'])):
+							if (not row['title']) or (titleExclusion.match(str.casefold(row['title']))):
 								continue
 						except:
 							# No title or {'title': null}

--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -39,13 +39,17 @@ def extractData(args):
 		""" Returns the numeric ID for the specified type """
 		return cursor.execute('SELECT id FROM GamePieceTypes WHERE type="{}"'.format(name)).fetchone()[0]
 
+	def clean(s):
+		""" Cleans strings for CSV consumption """
+		s = re.sub(r'\s*?(?:\r?\n|<br\s*/?>)', '\\\\n', s)  # Convert CRLF, LF, <br> into '\n' string
+		return s
+
 	def jls(name, bReturnCleanedString=False):
 		""" json.loads(`name`), optionally returning the purified sub-object of the same name,
 		    for cases such as {`name`: {`name`: "string"}}
 		"""
 		v = json.loads(result[positions[name]])
-		return re.sub(r'<br\s*/?>', '\\\\n', v[name].replace('\n', '\\n')) if bReturnCleanedString else v
-
+		return clean(v[name]) if bReturnCleanedString else v
 
 	def prepare(resultName, fields, dbField=None, dbRef=None, dbCondition=None, dbResultField=None, dbGroupBy=None):
 		""" Wrapper around the statement preparation and result parsing\n


### PR DESCRIPTION
* added: optional CSV delimiter for localised import
* ~removed: useless platformList queries~
* added: summary export
* Introduced a mini connection manager, to ensure proper cleanup even on an unhandled exception
* Split the queries into manageable chunks
* Created a wrapper to make addition of new fields manageable and self-contained
* Renamed some of the `MasterList` aliases to avoid confusion
* Fixed text parsing and included CR in the new line checks
* Partial DLC exclusion (their library is a bit of a mess, we'll need some manual specification)

It's quite a bit to digest, and slightly overkill, but "in for a penny, in for a pound", am I right?

For the sake of keeping things DRY I created a couple mini wrappers that reduce the boilerplate needed for this thing to work, mainly the `ba()`, `id()` and `jsl()` functions, all tiny and documented. Also, to keep things independent without going crazy, I created a parametrised `prepare()` function, that setups the query and helper variables to be used when parsing results.

For example, after the introduction of `prepare()`, when adding fields to the CSV we no longer have to track the results order manually, accessing them `results[int]` is not viable and `results[positions['name']]` avoids mistakes and debug headaches.

There is also the option to provide CSV fields by parsing content already available from the query. ~While doing this I noticed that the `platformList` queries were completely unnecessary and redundant, so I stripped the code of them.~

As for the `jsl()` I've added some parsing to be used with `title` and `summary`, that cleans up a bit of `\n` and `<br/>` to makes the CSV more consistent and accessible.

Let me know what you think.

**Edit:** noticed that the `platformList` was helpful in de-duping elements with diverging titles, so I reintroduced it.