### PR TITLE
Tags export and list merging

### DIFF
--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -415,7 +415,7 @@ if __name__ == "__main__":
 			[
 				['-d'],
 				{
-					'default': ',',
+					'default': '\t',
 					'type': str,
 					'required': False,
 					'metavar': 'CHARACTER',

--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -50,6 +50,7 @@ class Type(Enum):
 	STRING_JSON = 1
 	INTEGER = 10
 	DATE = 20
+	LIST = 30
 
 class Positions(dict):
 	""" small dictionary to avoid errors while parsing non-exported field positions """
@@ -86,7 +87,7 @@ def extractData(args):
 		v = v[name]
 		return clean(v) if isinstance(v, str) else v
 
-	def prepare(resultName, fields, dbField=None, dbRef=None, dbCondition=None, dbResultField=None, dbGroupBy=None):
+	def prepare(resultName, fields, dbField=None, dbRef=None, dbCondition=None, dbCustomJoin=None, dbResultField=None, dbGroupBy=None):
 		""" Wrapper around the statement preparation and result parsing\n
 			`resultName` cli argument variable name\n
 			`fields` {`title` to be inserted in the CSV: `boolean condition`, …}\n
@@ -107,12 +108,14 @@ def extractData(args):
 			og_references.append(', {}'.format(dbRef))
 		if dbCondition:
 			og_conditions.append(' AND ({})'.format(dbCondition))
+		if dbCustomJoin:
+			og_joins.append(' ' + dbCustomJoin)
 		if dbResultField:
 			og_resultFields.append(dbResultField)
 		if dbGroupBy:
 			og_resultGroupBy.append(dbGroupBy)
 	
-	def includeField(object, columnName, fieldName=None, fieldType=Type.STRING, paramName=None):
+	def includeField(object, columnName, fieldName=None, fieldType=Type.STRING, paramName=None, delimiter=','):
 		if args[columnName if not paramName else paramName]:
 			if None is fieldName:
 				fieldName = columnName
@@ -125,6 +128,9 @@ def extractData(args):
 					row[columnName] = object[fieldName]
 				elif Type.STRING_JSON is fieldType:
 					row[columnName] = jld(fieldName, True)
+				elif Type.LIST is fieldType:
+					s = object[fieldName].split(delimiter)
+					row[columnName] = set(s) if 1 < len(s) else objectFieldName
 			except:
 				row[columnName] = object[fieldName]
 
@@ -161,6 +167,7 @@ def extractData(args):
 		fieldnames = ['title']
 		og_fields = ["""CREATE TEMP VIEW MasterDB AS SELECT DISTINCT(MasterList.releaseKey) AS releaseKey, MasterList.value AS title, PLATFORMS.value AS platformList"""]
 		og_references = [""" FROM MasterList, MasterList AS PLATFORMS"""]
+		og_joins = []
 		og_conditions = [""" WHERE ((MasterList.gamePieceTypeId={}) OR (MasterList.gamePieceTypeId={})) AND ((PLATFORMS.releaseKey=MasterList.releaseKey) AND (PLATFORMS.gamePieceTypeId={}))""".format(
 					id('originalTitle'),
 					id('title'),
@@ -176,10 +183,10 @@ def extractData(args):
 			prepare(
 				'summary',
 				{'summary': True},
-				'SUMMARY.value AS summary',
-				'MasterList AS SUMMARY',
-				'(SUMMARY.releaseKey=MasterList.releaseKey) AND (SUMMARY.gamePieceTypeId={})'.format(id('summary')),
-				'MasterDB.summary'
+				dbField='SUMMARY.value AS summary',
+				dbRef='MasterList AS SUMMARY',
+				dbCondition='(SUMMARY.releaseKey=MasterList.releaseKey) AND (SUMMARY.gamePieceTypeId={})'.format(id('summary')),
+				dbResultField='MasterDB.summary'
 			)
 
 		if args.platforms:
@@ -199,29 +206,38 @@ def extractData(args):
 					'releaseDate': args.releaseDate,
 					'themes': args.themes,
 				},
-				'METADATA.value AS metadata',
-				'MasterList AS METADATA',
-				'(METADATA.releaseKey=MasterList.releaseKey) AND ((METADATA.gamePieceTypeId={}) OR (METADATA.gamePieceTypeId={}))'.format(id('originalMeta'), id('meta')),
-				'MasterDB.metadata'
+				dbField='METADATA.value AS metadata',
+				dbRef='MasterList AS METADATA',
+				dbCondition='(METADATA.releaseKey=MasterList.releaseKey) AND ((METADATA.gamePieceTypeId={}) OR (METADATA.gamePieceTypeId={}))'.format(id('originalMeta'), id('meta')),
+				dbResultField='MasterDB.metadata'
 			)
 
 		if args.playtime:
 			prepare(
 				'playtime',
 				{'gameMins': True},
-				'GAMETIMES.minutesInGame AS time',
-				'GAMETIMES',
-				'GAMETIMES.releaseKey=MasterList.releaseKey',
-				'sum(MasterDB.time)'
+				dbField='GAMETIMES.minutesInGame AS time',
+				dbRef='GAMETIMES',
+				dbCondition='GAMETIMES.releaseKey=MasterList.releaseKey',
+				dbResultField='sum(MasterDB.time)'
+			)
+
+		if args.tags:
+			prepare(
+				'tags',
+				{'tags': True},
+				dbField='USERRELEASETAGS.tag AS tags',
+				dbCustomJoin='LEFT JOIN USERRELEASETAGS ON USERRELEASETAGS.releaseKey=MasterList.releaseKey',
+				dbResultField='GROUP_CONCAT(MasterDB.tags)'
 			)
 
 		prepare(  # Grab a list of DLCs for filtering, regardless of whether we're exporting them or not
 			'dlcs',
 			{'dlcs': args.dlcs},
-			'DLC.value AS dlcs',
-			'MasterList AS DLC',
-			'(DLC.releaseKey=MasterList.releaseKey) AND (DLC.gamePieceTypeId={})'.format(id('dlcs')),
-			'MasterDB.dlcs'
+			dbField='DLC.value AS dlcs',
+			dbRef='MasterList AS DLC',
+			dbCondition='(DLC.releaseKey=MasterList.releaseKey) AND (DLC.gamePieceTypeId={})'.format(id('dlcs')),
+			dbResultField='MasterDB.dlcs'
 		)
 
 		if args.imageBackground or args.imageSquare or args.imageVertical:
@@ -232,10 +248,10 @@ def extractData(args):
 					'squareIcon': args.imageSquare,
 					'verticalCover': args.imageVertical
 				},
-				'IMAGES.value AS images',
-				'MasterList AS IMAGES',
-				'(IMAGES.releaseKey=MasterList.releaseKey) AND (IMAGES.gamePieceTypeId={})'.format(id('originalImages')),
-				'MasterDB.images'
+				dbField='IMAGES.value AS images',
+				dbRef='MasterList AS IMAGES',
+				dbCondition='(IMAGES.releaseKey=MasterList.releaseKey) AND (IMAGES.gamePieceTypeId={})'.format(id('originalImages')),
+				dbResultField='MasterDB.images'
 			)
 
 		# Display each game and its details along with corresponding release key grouped by releasesList
@@ -246,7 +262,7 @@ def extractData(args):
 
 		# Perform the queries
 		cursor.execute(owned_game_database)
-		cursor.execute(''.join(og_fields + og_references + og_conditions) + og_order)
+		cursor.execute(''.join(og_fields + og_references + og_joins + og_conditions) + og_order)
 		cursor.execute(unique_game_data)
 
 		# Prepare a list of games and DLCs
@@ -336,6 +352,10 @@ def extractData(args):
 								except StopIteration:
 									pass
 
+						# Tags
+						if args.tags:
+							includeField(result, 'tags', positions['tags'], fieldType=Type.LIST)
+
 						# Set conversion, list sorting, empty value reset
 						for k,v in row.items():
 							if v:
@@ -415,6 +435,7 @@ if __name__ == "__main__":
 			[['--publishers'], ba('publishers', 'list of publishers')],
 			[['--release-date'], ba('releaseDate', 'release date of the software')],
 			[['--summary'], ba('summary', 'game summary')],
+			[['--tags'], ba('tags', 'user tags')],
 			[['--themes'], ba('themes', 'game themes')],
 			[['--playtime'], ba('playtime', 'time spent playing the game')],
 		],

--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -28,6 +28,7 @@ class Arguments():
 		self.__parser.print_help()
 
 	def anyOption(self, exceptions):
+		self.notExportOptions = exceptions
 		for k,v in self.__args.__dict__.items():
 			if (k not in exceptions) and v:
 				return True
@@ -38,7 +39,7 @@ class Arguments():
 
 	def __getattr__(self, name):
 		ret = getattr(self.__args, name)
-		if isinstance(ret, bool):
+		if isinstance(ret, bool) and (name not in self.notExportOptions):
 			ret = self.__bAll or ret
 		elif isinstance(ret, list) and (1 == len(ret)):
 			ret = ret[0]
@@ -361,6 +362,8 @@ def extractData(args):
 							if v:
 								if list == type(v) or set == type(v):
 									row[k] = natsorted(list(row[k]), key=str.casefold)
+									if not args.pythonLists:
+										row[k] = args.delimiter.join(row[k])
 							else:
 								row[k] = ''
 
@@ -438,11 +441,12 @@ if __name__ == "__main__":
 			[['--tags'], ba('tags', 'user tags')],
 			[['--themes'], ba('themes', 'game themes')],
 			[['--playtime'], ba('playtime', 'time spent playing the game')],
+			[['--py-lists'], ba('pythonLists', 'export lists as Python parseable instead of delimiter separated strings')],
 		],
 		description='GOG Galaxy 2 exporter: scans the local Galaxy 2 database to export a list of games and related information into a CSV'
 	)
 
-	if args.anyOption(['delimiter', 'fileCSV', 'fileDB']):
+	if args.anyOption(['delimiter', 'fileCSV', 'fileDB', 'pythonLists']):
 		if exists(args.fileDB):
 			extractData(args)
 		else:

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,8 @@ When a different locale wants a different CSV delimiter (such as the Italian), y
 
 Also, you can manually specify the database location (`-i`) and the CSV location (`-o`), instead of using the default ones.
 
+If the CSV has to be read by a Python script, you can use the option `--py-lists` to export python compatible list strings that can be reconverted in python objects through `ast`'s `literal_eval`, which avoids several (potentially incorrect) string split/joins.
+
 ## Dependencies
 
 - Python 3


### PR DESCRIPTION
Closes #26
Closes #28

Took me a bit but finally got around to it. I've changed the default delimiter to TAB, and enabled list merging by default, which should result in a perfectly valid and readable CSV in the absolute majority of the cases. I've still retained the "python parseable" lists through a new option `--py-lists`, as documented in the readme.