### PR TITLE
Fix sort order

### DIFF
--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -311,7 +311,7 @@ def extractData(args):
 			if d:
 				for dlc in d:
 					dlcs.add(dlc)
-		results = natsorted(results, key=lambda r: str.casefold(r[1][positions['sortingTitle']]))
+		results = natsorted(results, key=lambda r: str.casefold(str(json.loads(r[1][positions['sortingTitle']])['title'])))
 
 		# Exclude games mistakenly treated as DLCs, such as "3 out of 10, EP2"
 		for dlc in options['TreatDLCAsGame']:


### PR DESCRIPTION
sortingTitle has two fileds:
```json
{
    isModifiedByUser: boolean;
    title: string;
}
```
The sorting method uses the whole json string instead of the title field. That's why all games with a modified title are added to the end of the exported list.
`"isModifiedByUser":false` vs `"isModifiedByUser":true`