### PR TITLE
Fix title and metadata export

### DIFF
--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -240,17 +240,24 @@ def extractData(args):
 				{'platformList': True},
 			)
 
-		if args.criticsScore or args.developers or args.genres or args.publishers or args.releaseDate or args.themes:
-			prepare(
-				'metadata',
-				{
+		# add filednames of metadata and orginalMetadata
+		# this allows to order them in a way that metadata values are followed by their related originalMetadata value in the export
+		for name,condition in {
 					'criticsScore': args.criticsScore,
 					'developers': args.developers,
 					'genres': args.genres,
 					'publishers': args.publishers,
 					'releaseDate': args.releaseDate,
+					'originalReleaseDate': args.originalReleaseDate,
 					'themes': args.themes,
-				},
+				}.items():
+			if condition:
+				fieldnames.append(name)
+			
+		if args.criticsScore or args.developers or args.genres or args.publishers or args.releaseDate or args.themes:
+			prepare(
+				'metadata',
+				{}, # fieldnames are added separateley together with their related originalMetadata fields
 				dbField='METADATA.value AS metadata',
 				dbRef='MasterList AS METADATA',
 				dbCondition='METADATA.releaseKey=MasterList.releaseKey AND METADATA.gamePieceTypeId={}'.format(id('meta')),
@@ -260,11 +267,7 @@ def extractData(args):
 		if args.originalReleaseDate:
 			prepare(
 				'originalMetadata',
-				{
-					# in the current galaxy2 release only the release date is customizable
-					# if future releases add support for more customizable meta data extend this list
-					'originalReleaseDate': args.originalReleaseDate,
-				},
+				{}, # fieldnames are added separateley together with their related metadata fields
 				dbField='ORIGINALMETADATA.value AS originalMetadata',
 				dbRef='MasterList AS ORIGINALMETADATA',
 				dbCondition='ORIGINALMETADATA.releaseKey=MasterList.releaseKey AND ORIGINALMETADATA.gamePieceTypeId={}'.format(id('originalMeta')),

--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -253,8 +253,22 @@ def extractData(args):
 				},
 				dbField='METADATA.value AS metadata',
 				dbRef='MasterList AS METADATA',
-				dbCondition='(METADATA.releaseKey=MasterList.releaseKey) AND ((METADATA.gamePieceTypeId={}) OR (METADATA.gamePieceTypeId={}))'.format(id('originalMeta'), id('meta')),
+				dbCondition='METADATA.releaseKey=MasterList.releaseKey AND METADATA.gamePieceTypeId={}'.format(id('meta')),
 				dbResultField='MasterDB.metadata'
+			)
+
+		if args.originalReleaseDate:
+			prepare(
+				'originalMetadata',
+				{
+					# in the current galaxy2 release only the release date is customizable
+					# if future releases add support for more customizable meta data extend this list
+					'originalReleaseDate': args.originalReleaseDate,
+				},
+				dbField='ORIGINALMETADATA.value AS originalMetadata',
+				dbRef='MasterList AS ORIGINALMETADATA',
+				dbCondition='ORIGINALMETADATA.releaseKey=MasterList.releaseKey AND ORIGINALMETADATA.gamePieceTypeId={}'.format(id('originalMeta')),
+				dbResultField='MasterDB.originalMetadata'
 			)
 
 		if args.playtime:
@@ -419,6 +433,11 @@ def extractData(args):
 							includeField(metadata, 'releaseDate', fieldType=Type.DATE)
 							includeField(metadata, 'themes')
 
+						# Original metadata
+						if args.originalReleaseDate:
+							originalMetadata = jld('originalMetadata')
+							includeField(originalMetadata, 'originalReleaseDate', 'releaseDate', fieldType=Type.DATE)
+
 						# Original images
 						if args.imageBackground or args.imageSquare or args.imageVertical:
 							images = jld('images')
@@ -539,7 +558,8 @@ if __name__ == "__main__":
 			[['--image-vertical'], ba('imageVertical', 'vertical cover image')],
 			[['--platforms'], ba('platforms', 'list of platforms the game is available on')],
 			[['--publishers'], ba('publishers', 'list of publishers')],
-			[['--release-date'], ba('releaseDate', 'release date of the software')],
+			[['--release-date'], ba('releaseDate', '(user customized) release date of the software')],
+			[['--release-date-original'], ba('originalReleaseDate', 'original release date independent of any user changes')],
 			[['--summary'], ba('summary', 'game summary')],
 			[['--tags'], ba('tags', 'user tags')],
 			[['--hidden'], ba('isHidden', 'is gamne hidden in galaxy client')],


### PR DESCRIPTION
This should fix https://github.com/AB1908/GOG-Galaxy-Export-Script/issues/40
- `title` is used as standard and `originalTitle` is added as additional export
- separated `meta` and `originalMeta`