### PR TITLE
New feature: treat release as dlc

### DIFF
--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -70,7 +70,7 @@ def extractData(args):
 
 	def loadOptions():
 		""" Loads options from `settings.json` and initialises defaults """
-		defaults = {"TreatDLCAsGame": []}
+		defaults = {"TreatDLCAsGame": [], "TreatReleaseAsDLC": {}}
 
 		# Load settings from disk
 		try:
@@ -363,6 +363,11 @@ def extractData(args):
 		for dlc in options['TreatDLCAsGame']:
 			dlcs.discard(dlc)
 
+		# Add dlcs mistakenly treated as games, such as "Grey Goo - Emergence Campaign"
+		additionalDLCs = options['TreatReleaseAsDLC']
+		for game in additionalDLCs.keys():
+			dlcs.update(additionalDLCs[game])
+
 		# There are spurious random dlcNUMBERa entries in the library, plus a few DLCs which appear
 		# multiple times in different ways and are not attached to a game
 		titleExclusion = re.compile(r'^(?:'
@@ -452,15 +457,22 @@ def extractData(args):
 						if args.dlcs:
 							row['dlcs'] = set()
 							dlcList = jld('dlcs', True)
-							if dlcList:
-								for dlc in dlcList:
-									try:
-										# Check the availability of the DLC in the games list (uncertain)
-										d = next(x[1] for x in results if dlc in x[0])
-										if d:
-											row['dlcs'].add(jld('title', True, d))
-									except StopIteration:
-										pass
+							if dlcList == None:
+								dlcList = []
+							if options["TreatReleaseAsDLC"]:
+								rkeys = result[positions['releaseKey']].split(',')
+								for key in rkeys:
+									if options["TreatReleaseAsDLC"].get(key) != None:
+										dlcList.extend(options["TreatReleaseAsDLC"][key])
+								
+							for dlc in dlcList:
+								try:
+									# Check the availability of the DLC in the games list (uncertain)
+									d = next(x[1] for x in results if dlc in x[0])
+									if d:
+										row['dlcs'].add(jld('title', True, d))
+								except StopIteration:
+									pass
 
 						# Tags
 						if args.tags:

--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -385,7 +385,7 @@ def extractData(args):
 				writer.writeheader()
 				for (ids, result) in results:
 					# Only consider games for the list, not DLCs
-					if 0 < len([x for x in ids if x in dlcs]):
+					if not args.exportDlcDetails and 0 < len([x for x in ids if x in dlcs]):
 						continue
 
 					try:
@@ -581,12 +581,13 @@ if __name__ == "__main__":
 			[['--os-compatibility'], ba('osCompatibility', 'list of supported operating systems')],
 			[['--themes'], ba('themes', 'game themes')],
 			[['--playtime'], ba('playtime', 'time spent playing the game')],
+			[['--dlcs-details'], ba('exportDlcDetails', 'add a separate entry for each dlc with all available information to the exported csv')],
 			[['--py-lists'], ba('pythonLists', 'export lists as Python parseable instead of delimiter separated strings')],
 		],
 		description='GOG Galaxy 2 exporter: scans the local Galaxy 2 database to export a list of games and related information into a CSV'
 	)
 
-	if not args.anyOption(['delimiter', 'fileCSV', 'fileDB', 'pythonLists']):
+	if not args.anyOption(['delimiter', 'fileCSV', 'fileDB', 'pythonLists', 'exportDlcDetails']):
 		args.extractAll()
 	if exists(args.fileDB):
 		extractData(args)

--- a/readme.md
+++ b/readme.md
@@ -8,11 +8,28 @@ Through the use of command line parameters, you can decide what data you want ex
 
 If you want to use the CSV in a different tool, such as the [HTML5 library exporter](https://github.com/Varstahl/GOG-Galaxy-HTML5-exporter), you can default to the `-a` parameter to export everything.
 
-When a different locale wants a different CSV delimiter (such as the Italian), you can manually specify the character to use (`-D <character>`).
+When a different locale wants a different CSV delimiter (such as the Italian), you can manually specify the character to use (`-d <character>`).
 
 Also, you can manually specify the database location (`-i`) and the CSV location (`-o`), instead of using the default ones.
 
 If the CSV has to be read by a Python script, you can use the option `--py-lists` to export python compatible list strings that can be reconverted in python objects through `ast`'s `literal_eval`, which avoids several (potentially incorrect) string split/joins.
+
+If you also want to export all available dlcs use the `--dlcs-details` argument. With that all dlcs are handled as "games" and will be exported with all available infos.
+
+## settings.json
+
+The settings.json allows to handle dlcs as game and export them accordingly or treat any release (game, dlc, soundtrack, goodies pack etc.) as dlc of another game, if they are not already linked in the database.
+
+- *TreatDLCAsGame*: Aarray of release-keys which should be treated as a game instead of a dlc
+  - Used to mark games which are (mistakenly) treated as dlcs by the gog galaxy client as games.
+  - All entries with a matching release-key will be exported with all available data.
+  - This will not change the link between a dlc and his parent game if it really is a dlc.
+- *TreatReleaseAsDLC*: Dictionary which maps the releaseKey of a game to a list of dlcs.
+  - Used to mark any release which is (mistakenly) treated as a game by the gog galaxy client as dlc.
+  - The dlcs specified in the settings.json are joined with the list of dlcs found in the database.
+  - *TreatReleaseAsDLC* is evaluated after *TreatDLCAsGame*. If a release-key is present in *TreatDLCAsGame* and also mapped to another release-key with *TreatReleaseAsDLC* than this release-key is handled as dlc.
+  - This will not override the original link between a dlc and it's parent game. If a dlc is mapped to another game it will be present in the dlc list of this game and the original game.
+
 
 ## Dependencies
 

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,9 @@
 {
-  "TreatDLCAsGame": [
-    "epic_1317e4e3b3ed40c289dde85b194347d3"
-  ]
+	"TreatDLCAsGame": [
+		"epic_1317e4e3b3ed40c289dde85b194347d3"
+	],
+	"TreatReleaseAsDLC": {
+		"steam_290790": ["steam_357180","steam_341810"],
+		"steam_365450": ["steam_408710"]
+	}
 }


### PR DESCRIPTION
It is already possible to mark a dlc as a game for the script, independent of the type in the database. So games mistakenly marked as dlc can be exported accordingly.
But more often it is the other way around. A dlc is not marked as such in the database and will be treated as a game by the export script.
That's why I added the _TreatReleaseAsDLC_ option to the settings.json which allows to map any release-key to a parent release-key.

The new argument _--dlcs-details_ adds all dlcs to the export (if someone needs that info).