### PR TITLE
adapted script to latest changes of gog galaxy (release 2.0.44)

### DIFF
--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -181,10 +181,10 @@ def extractData(args):
 	options = loadOptions()
 
 	with OpenDB() as cursor:
-		# Create a view of GameLinks joined on GamePieces for a full owned game data DB
+		# Create a view of ProductPurchaseDates (= purchased/added games) joined on GamePieces for a full owned game data DB
 		owned_game_database = """CREATE TEMP VIEW MasterList AS
-				SELECT GamePieces.releaseKey, GamePieces.gamePieceTypeId, GamePieces.value FROM GameLinks
-				JOIN GamePieces ON GameLinks.releaseKey = GamePieces.releaseKey;"""
+				SELECT GamePieces.releaseKey, GamePieces.gamePieceTypeId, GamePieces.value FROM ProductPurchaseDates
+				JOIN GamePieces ON ProductPurchaseDates.gameReleaseKey = GamePieces.releaseKey;"""
 
 		# Set up default queries and processing metadata, and always extract the game title along with any parameters
 		prepare.nextPos = 2


### PR DESCRIPTION
With the 2.0.44 release of GOG Galaxy the GameLinks table was removed from the database.
I found two tables which could be used instead: LibraryReleases or ProductPurchaseDates.
In the end I used ProductPurchaseDates because with LibraryReleases the export contained some additional games which are no longer in my library.

The ProductPurchaseDates table is not new so the script is backwards compatible.

The result is not exactly the same as with the GameLinks table (tested with a database backup < 2.0.44). A few releases are missing in the export when using ProductPurchaseDates but only releases which are not visible in the galaxy client.

---
fixes https://github.com/AB1908/GOG-Galaxy-Export-Script/issues/52