### PR TITLE
Added support for macOS

### DIFF
--- a/galaxy_library_export.py
+++ b/galaxy_library_export.py
@@ -9,6 +9,7 @@ from os.path import exists
 import re
 import sqlite3
 import time
+from sys import platform
 
 class Arguments():
 	""" argparse wrapper, to reduce code verbosity """
@@ -522,7 +523,12 @@ def extractData(args):
 			return
 
 if __name__ == "__main__":
-	defaultDBlocation = 'C:\\ProgramData\\GOG.com\\Galaxy\\storage\\galaxy-2.0.db'
+	# macOS
+	if platform == "darwin":
+		defaultDBlocation = "/Users/Shared/GOG.com/Galaxy/Storage/galaxy-2.0.db"
+	# Windows
+	elif platform == "win32":
+		defaultDBlocation = "C:\\ProgramData\\GOG.com\\Galaxy\\storage\\galaxy-2.0.db"
 
 	def ba(variableName, description, defaultValue=False):
 		""" Boolean argument: creates a default boolean argument with the name of the storage variable and


### PR DESCRIPTION
Just added basic support for macOS. Only tested on macOS; technically, branching logic for Windows case needs to be tested, still, but it should work as it had previously.

Didn't immediately see any other code dependent on OS/platform other than the default GOG Galaxy games DB filepath, but could use another set of eyes.